### PR TITLE
Auto-generate docs - do not populate `Options` header when `options[]` is undefined

### DIFF
--- a/src/generateDocs.ts
+++ b/src/generateDocs.ts
@@ -18,8 +18,6 @@ const FEATURES_README_TEMPLATE = `
 }
 \`\`\`
 
-## Options
-
 #{OptionsTable}
 
 #{Notes}
@@ -33,8 +31,6 @@ const TEMPLATE_README_TEMPLATE = `
 # #{Name}
 
 #{Description}
-
-## Options
 
 #{OptionsTable}
 
@@ -107,7 +103,7 @@ async function _generateDocumentation(basePath: string, readmeTemplate: string, 
                         })
                         .join('\n');
 
-                    return '| Options Id | Description | Type | Default Value |\n' + '|-----|-----|-----|-----|\n' + contents;
+                    return '## Options\n\n' + '| Options Id | Description | Type | Default Value |\n' + '|-----|-----|-----|-----|\n' + contents;
                 };
 
                 const generateNotesMarkdown = () => {


### PR DESCRIPTION
Fixes - where `devcontainer-*.json` does not have `options[]`. However, the `Options` headline is present in the README. Fixing that.

Sample - https://github.com/devcontainers/templates/blob/main/src/kubernetes-helm-minikube/README.md#options
 