### PR TITLE
Differentiate `false` and `undefined` default values

### DIFF
--- a/src/generateDocs.ts
+++ b/src/generateDocs.ts
@@ -99,7 +99,12 @@ async function _generateDocumentation(basePath: string, readmeTemplate: string, 
                     const contents = keys
                         .map(k => {
                             const val = options[k];
-                            return `| ${k} | ${val.description || '-'} | ${val.type || '-'} | ${val.default || '-'} |`;
+                            
+                            const desc = val.description || '-';
+                            const type = val.type || '-';
+                            const def = val.default !== undefined ? val.default : '-'
+                            
+                            return `| ${k} | ${desc} | ${type} | ${def} |`;
                         })
                         .join('\n');
 

--- a/src/generateDocs.ts
+++ b/src/generateDocs.ts
@@ -102,7 +102,7 @@ async function _generateDocumentation(basePath: string, readmeTemplate: string, 
                             
                             const desc = val.description || '-';
                             const type = val.type || '-';
-                            const def = val.default !== undefined ? val.default : '-'
+                            const def = val.default !== undefined ? val.default : '-';
                             
                             return `| ${k} | ${desc} | ${type} | ${def} |`;
                         })


### PR DESCRIPTION
Fixes: https://github.com/devcontainers/action/issues/92

Adds a check to the doc generator to look for `undefined` default value explicitly. This fixes the case where the default is `false` resulting in a `-` even though the default exists.

See sample PR in my fork: https://github.com/cmbrose/devcontainer-features/pull/2/files?short_path=1e9bd8e#diff-1e9bd8ea7bae8a4b7a286ec2d745e622ecf5af67a1facc75785e427b36e6ad17

![image](https://user-images.githubusercontent.com/5447118/199042461-4817d085-35fa-4f92-abcf-09c132b1edad.png)
