### PR TITLE
Change to empty object in Features example usage

### DIFF
--- a/src/generateDocs.ts
+++ b/src/generateDocs.ts
@@ -12,9 +12,7 @@ const FEATURES_README_TEMPLATE = `
 
 \`\`\`json
 "features": {
-    "#{Registry}/#{Namespace}/#{Id}:#{Version}": {
-        "version": "latest"
-    }
+    "#{Registry}/#{Namespace}/#{Id}:#{Version}": {}
 }
 \`\`\`
 


### PR DESCRIPTION
closes https://github.com/devcontainers/action/issues/85

Not every Feature will define `version` as an option, therefore it should not be left as the example.  Following how the GitHub web editor and VS Code extensions emit the Feature, change the example to an empty options object.