### PR TITLE
validate `devcontainer-feature.json` schema

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,14 @@ jobs:
         with:
           node-version: 16.x
 
+      # - name: Update Schemas
+      #   run: yarn fetch-schemas
+
       - name: Install dependencies
         run: rm -rf node_modules && yarn
+
+      - name: Run unit tests
+        run: yarn test
 
       - name: Build
         run: yarn build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+    
+      - name: Set Node.js 16.x
+        uses: actions/setup-node@v2.5.1
+        with:
+          node-version: 16.x
+
+      - name: Update Schemas
+        run: yarn fetch-schemas
+
+      - name: Install dependencies
+        run: rm -rf node_modules && yarn
+
+      - name: Run unit tests
+        run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
     
       - name: Set Node.js 16.x
         uses: actions/setup-node@v2.5.1

--- a/__tests__/examples/invalid/src/invalidPropertyName/devcontainer-feature.json
+++ b/__tests__/examples/invalid/src/invalidPropertyName/devcontainer-feature.json
@@ -1,0 +1,19 @@
+{
+    "name": "My Favorite Color",
+    "id": "color",
+    "version": "1.0.3",
+    "description": "A feature to remind you of your favorite color",
+    "options": {
+        "favorite": {
+            "type": "string",
+            "enum": [
+                "red",
+                "gold",
+                "green"
+            ],
+            "default": "red",
+            "description": "Choose your favorite color."
+        }
+    },
+    "installAfter": []
+}

--- a/__tests__/examples/invalid/src/invalidPropertyName/install.sh
+++ b/__tests__/examples/invalid/src/invalidPropertyName/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'install.sh....'

--- a/__tests__/examples/invalid/src/invalidPropertyValue/devcontainer-feature.json
+++ b/__tests__/examples/invalid/src/invalidPropertyValue/devcontainer-feature.json
@@ -1,0 +1,20 @@
+{
+    "name": "Hello, World!",
+    "id": "hello",
+    "version": "1.0.2",
+    "description": "A hello world feature",
+    "options": {
+        "greeting": {
+            "type": "string",
+            "proposals": [
+                "hey",
+                "hello",
+                "hi",
+                "howdy"
+            ],
+            "default": "hey",
+            "description": "Select a pre-made greeting, or enter your own"
+        }
+    },
+    "installsAfter": {}
+}

--- a/__tests__/examples/invalid/src/invalidPropertyValue/install.sh
+++ b/__tests__/examples/invalid/src/invalidPropertyValue/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'install.sh....'

--- a/__tests__/examples/invalid/src/missingProperty/devcontainer-feature.json
+++ b/__tests__/examples/invalid/src/missingProperty/devcontainer-feature.json
@@ -1,0 +1,5 @@
+{
+    "name": "My Favorite Color",
+    "version": "1.0.3",
+    "description": "A feature to remind you of your favorite color"
+}

--- a/__tests__/examples/invalid/src/missingProperty/install.sh
+++ b/__tests__/examples/invalid/src/missingProperty/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'install.sh....'

--- a/__tests__/examples/simple/src/color/devcontainer-feature.json
+++ b/__tests__/examples/simple/src/color/devcontainer-feature.json
@@ -1,0 +1,19 @@
+{
+    "name": "My Favorite Color",
+    "id": "color",
+    "version": "1.0.3",
+    "description": "A feature to remind you of your favorite color",
+    "options": {
+        "favorite": {
+            "type": "string",
+            "enum": [
+                "red",
+                "gold",
+                "green"
+            ],
+            "default": "red",
+            "description": "Choose your favorite color."
+        }
+    },
+    "installsAfter": []
+}

--- a/__tests__/examples/simple/src/color/install.sh
+++ b/__tests__/examples/simple/src/color/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'install.sh....'

--- a/__tests__/examples/simple/src/hello/devcontainer-feature.json
+++ b/__tests__/examples/simple/src/hello/devcontainer-feature.json
@@ -1,0 +1,19 @@
+{
+    "name": "Hello, World!",
+    "id": "hello",
+    "version": "1.0.2",
+    "description": "A hello world feature",
+    "options": {
+        "greeting": {
+            "type": "string",
+            "proposals": [
+                "hey",
+                "hello",
+                "hi",
+                "howdy"
+            ],
+            "default": "hey",
+            "description": "Select a pre-made greeting, or enter your own"
+        }
+    }
+}

--- a/__tests__/examples/simple/src/hello/install.sh
+++ b/__tests__/examples/simple/src/hello/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'install.sh....'

--- a/__tests__/validateSchema.test.ts
+++ b/__tests__/validateSchema.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@jest/globals';
+import * as path from 'path';
+import { validateFeatureSchema } from '../src/utils';
+
+test('validateSchema', async () => {
+    const exampleRepos = path.join(__dirname, 'examples');
+
+    {
+        // VALID
+        const result = await validateFeatureSchema(path.join(exampleRepos, 'simple', 'src', 'color'));
+        expect(result).toBe(true);
+    }
+
+    {
+        // VALID
+        const result = await validateFeatureSchema(path.join(exampleRepos, 'simple', 'src', 'hello'));
+        expect(result).toBe(true);
+    }
+
+    {
+        // WRONG: 'installAfter' should be changed to 'installsAfter'
+        const result = await validateFeatureSchema(path.join(exampleRepos, 'invalid', 'src', 'invalidPropertyName'));
+        expect(result).toBe(false);
+    }
+
+    {
+        // WRONG: 'installsAfter' value should be an array, but is an object
+        const result = await validateFeatureSchema(path.join(exampleRepos, 'invalid', 'src', 'invalidPropertyValue'));
+        expect(result).toBe(false);
+    }
+
+    {
+        // WRONG: missing required 'id' property
+        const result = await validateFeatureSchema(path.join(exampleRepos, 'invalid', 'src', 'missingProperty'));
+        expect(result).toBe(false);
+    }
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   clearMocks: true,
   moduleFileExtensions: ['js', 'ts'],
   testMatch: ['**/*.test.ts'],
+  testEnvironment: 'node',
   transform: {
     '^.+\\.ts$': 'ts-jest'
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "format": "prettier --write '**/*.ts'",
     "format-check": "prettier --check '**/*.ts'",
     "build": "ncc build ./src/main.ts",
-    "test": "jest"
+    "test": "jest",
+    "fetch-schemas": "wget https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainerFeature.schema.json -O src/schemas/devContainerFeature.schema.json"
+
   },
   "repository": {
     "type": "git",
@@ -28,9 +30,11 @@
     "@actions/core": "^1.9.1",
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.1.1",
+    "ajv": "^8.11.2",
     "jsonc-parser": "^3.1.0"
   },
   "devDependencies": {
+    "@types/ajv": "^1.0.0",
     "@types/node": "^16.11.6",
     "@vercel/ncc": "^0.34.0",
     "copyfiles": "^2.4.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ async function run(): Promise<void> {
     if (shouldPublishFeatures) {
         core.info('Validating Feature metadata...');
         if (!(await prePublish('feature', featuresBasePath))) {
-            core.setFailed('(!) Failed to validate contents of Features.');
+            core.setFailed('(!) Failed to validate Feature metadata.');
             return;
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,11 @@
  *-------------------------------------------------------------------------------------------------------------*/
 
 import * as core from '@actions/core';
-import { generateFeaturesDocumentation, generateTemplateDocumentation } from './generateDocs';
-import { ensureDevcontainerCliPresent, getGitHubMetadata } from './utils';
 import * as exec from '@actions/exec';
+import * as path from 'path';
+
+import { generateFeaturesDocumentation, generateTemplateDocumentation } from './generateDocs';
+import { ensureDevcontainerCliPresent, getGitHubMetadata, readdirLocal, validateFeatureSchema } from './utils';
 
 async function run(): Promise<void> {
     core.debug('Reading input parameters...');
@@ -52,6 +54,12 @@ async function run(): Promise<void> {
     }
 
     if (shouldPublishFeatures) {
+        core.info('Validating Feature metadata...');
+        if (!(await prePublish('feature', featuresBasePath))) {
+            core.setFailed('(!) Failed to validate contents of Features.');
+            return;
+        }
+
         core.info('Publishing features...');
         if (!(await publish('feature', featuresBasePath, featuresOciRegistry, featuresNamespace, cliDebugMode))) {
             core.setFailed('(!) Failed to publish features.');
@@ -80,7 +88,31 @@ async function run(): Promise<void> {
     }
 }
 
-async function publish(collectionType: string, basePath: string, ociRegistry: string, namespace: string, cliDebugMode = false): Promise<boolean> {
+async function prePublish(collectionType: 'feature' | 'template', basePath: string): Promise<boolean> {
+    // Iterate each (Feature|Template) in 'basePath'
+    for (const folder of await readdirLocal(basePath)) {
+        const pathToArtifact = path.join(basePath, folder);
+
+        if (collectionType === 'feature') {
+            if (!(await validateFeatureSchema(pathToArtifact))) {
+                return false;
+            }
+        }
+
+        // if (collectionType == 'template') { }
+    }
+
+    // Validate never failed
+    return true;
+}
+
+async function publish(
+    collectionType: 'feature' | 'template',
+    basePath: string,
+    ociRegistry: string,
+    namespace: string,
+    cliDebugMode = false
+): Promise<boolean> {
     // Ensures we have the devcontainer CLI installed.
     if (!(await ensureDevcontainerCliPresent(cliDebugMode))) {
         core.setFailed('Failed to install devcontainer CLI');

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -1,0 +1,7 @@
+# Schemas
+
+Schemas can be updated by running `yarn update-schemas` from the root of the project. 
+
+The following schemas are synced:
+
+- `src/schemas/devContainerFeature.schema.json` - Defines a Feature's `devcontainer-feature.json` metadata file

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -1,6 +1,6 @@
 # Schemas
 
-Schemas can be updated by running `yarn update-schemas` from the root of the project. 
+Schemas can be updated by running `yarn fetch-schemas` from the root of the project. 
 
 The following schemas are synced:
 

--- a/src/schemas/devContainerFeature.schema.json
+++ b/src/schemas/devContainerFeature.schema.json
@@ -1,0 +1,225 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Development Container Feature Metadata",
+  "description": "Development Container Features Metadata (devcontainer-feature.json). See https://containers.dev/implementors/features/ for more information.",
+    "definitions": {
+    "Feature": {
+      "additionalProperties": false,
+      "properties": {
+        "capAdd": {
+					"description": "Passes docker capabilities to include when creating the dev container.",
+					"examples": [ "SYS_PTRACE" ],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "containerEnv": {
+          "description": "Container environment variables.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "customizations": {
+          "description": "Tool-specific configuration. Each tool should use a JSON object subproperty with a unique name to group its customizations.",
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "description": {
+          "description": "Description of the Feature. For the best appearance in an implementing tool, refrain from including markdown or HTML in the description.",
+          "type": "string"
+        },
+        "documentationURL": {
+          "description": "URL to documentation for the Feature.",
+          "type": "string"
+        },
+        "entrypoint": {
+          "description": "Entrypoint script that should fire at container start up.",
+          "type": "string"
+        },
+        "id": {
+          "description": "ID of the Feature. The id should be unique in the context of the repository/published package where the feature exists and must match the name of the directory where the devcontainer-feature.json resides.",
+          "type": "string"
+        },
+        "init": {
+          "description": "Adds the tiny init process to the container (--init) when the Feature is used.",
+          "type": "boolean"
+        },
+        "installsAfter": {
+          "description": "Array of ID's of Features that should execute before this one. Allows control for feature authors on soft dependencies between different Features.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "licenseURL": {
+          "description": "URL to the license for the Feature.",
+          "type": "string"
+        },
+        "mounts": {
+          "description": "Mounts a volume or bind mount into the container.",
+          "items": {
+            "$ref": "#/definitions/Mount"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Display name of the Feature.",
+          "type": "string"
+        },
+        "options": {
+          "description": "Possible user-configurable options for this Feature. The selected options will be passed as environment variables when installing the Feature into the container.",
+          "additionalProperties": {
+            "$ref": "#/definitions/FeatureOption"
+          },
+          "type": "object"
+        },
+        "privileged": {
+          "description": "Sets privileged mode (--privileged) for the container.",
+          "type": "boolean"
+        },
+        "securityOpt": {
+          "description": "Sets container security options to include when creating the container.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "version": {
+          "description": "The version of the Feature. Follows the semanatic versioning (semver) specification.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "version"
+      ],
+      "type": "object"
+    },
+    "FeatureOption": {
+      "anyOf": [
+        {
+          "description": "Option value is represented with a boolean value.",
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "description": "Default value if the user omits this option from their configuration.",
+              "type": "boolean"
+            },
+            "description": {
+              "description": "A description of the option displayed to the user by a supporting tool.",
+              "type": "string"
+            },
+            "type": {
+              "description": "The type of the option. Can be 'boolean' or 'string'.  Options of type 'string' should use the 'enum' or 'proposals' property to provide a list of allowed values.",
+              "const": "boolean",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "default"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "description": "Default value if the user omits this option from their configuration.",
+              "type": "string"
+            },
+            "description": {
+              "description": "A description of the option displayed to the user by a supporting tool.",
+              "type": "string"
+            },
+            "enum": {
+              "description": "Allowed values for this option.  Unlike 'proposals', the user cannot provide a custom value not included in the 'enum' array.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "description": "The type of the option. Can be 'boolean' or 'string'.  Options of type 'string' should use the 'enum' or 'proposals' property to provide a list of allowed values.",
+              "const": "string",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "enum",
+            "default"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "description": "Default value if the user omits this option from their configuration.",
+              "type": "string"
+            },
+            "description": {
+              "description": "A description of the option displayed to the user by a supporting tool.",
+              "type": "string"
+            },
+            "proposals": {
+              "description": "Suggested values for this option.  Unlike 'enum', the 'proposals' attribute indicates the installation script can handle arbitrary values provided by the user.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "description": "The type of the option. Can be 'boolean' or 'string'.  Options of type 'string' should use the 'enum' or 'proposals' property to provide a list of allowed values.",
+              "const": "string",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "proposals",
+            "default"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "Mount": {
+      "description": "Mounts a volume or bind mount into the container.",
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "description": "Mount source.",
+          "type": "string"
+        },
+        "target": {
+          "description": "Mount target.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of mount. Can be 'bind' or 'volume'.",
+          "enum": [
+            "bind",
+            "volume"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "source",
+        "target"
+      ],
+      "type": "object"
+    }
+  },
+  "oneOf": [
+    {
+      "type": "object",
+      "$ref": "#/definitions/Feature"
+      }
+  ]
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,14 @@
 import * as github from '@actions/github';
 import * as fs from 'fs';
-import { promisify } from 'util';
-import { GitHubMetadata } from './contracts/collection';
-import * as cp from 'child_process';
-import { Template } from './contracts/templates';
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
+import Ajv from 'ajv';
 import * as path from 'path';
+
+import { promisify } from 'util';
+import { GitHubMetadata } from './contracts/collection';
+import devContainerFeatureSchema from "./schemas/devContainerFeature.schema.json"
+
 
 export const readLocalFile = promisify(fs.readFile);
 export const writeLocalFile = promisify(fs.writeFile);
@@ -72,4 +74,34 @@ export async function ensureDevcontainerCliPresent(cliDebugMode = false): Promis
     } catch (err) {
         return false;
     }
+}
+
+export async function validateFeatureSchema(pathToAFeatureDir: string): Promise<boolean> {
+
+    const ajv = new Ajv();
+    ajv.addSchema(devContainerFeatureSchema);
+    const validate = ajv.compile(devContainerFeatureSchema);
+
+    const devContainerFeaturePath = path.join(pathToAFeatureDir, 'devcontainer-feature.json');
+
+    // Read this Feature's devcontainer-feature.json
+    if (!fs.existsSync(devContainerFeaturePath)) {
+        core.error(`(!) ERR: devcontainer-feature.json not found at path '${devContainerFeaturePath}'.`);
+        return false;
+    }
+
+    const featureJson = await readLocalFile(devContainerFeaturePath, 'utf8');
+
+
+    const isValid = validate(JSON.parse(featureJson));
+    if (!isValid) {
+        core.setFailed(`(!) ERR: '${devContainerFeaturePath}' is not valid:`);
+
+        const output = JSON.stringify(validate.errors, undefined, 4);
+        core.info(output);
+        return false;
+    }
+
+    // No parse errors.
+    return true;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,13 +7,13 @@ import * as path from 'path';
 
 import { promisify } from 'util';
 import { GitHubMetadata } from './contracts/collection';
-import devContainerFeatureSchema from "./schemas/devContainerFeature.schema.json"
-
+import devContainerFeatureSchema from './schemas/devContainerFeature.schema.json';
 
 export const readLocalFile = promisify(fs.readFile);
 export const writeLocalFile = promisify(fs.writeFile);
 export const mkdirLocal = promisify(fs.mkdir);
 export const renameLocal = promisify(fs.rename);
+export const readdirLocal = promisify(fs.readdir);
 
 export function getGitHubMetadata() {
     // Insert github repo metadata
@@ -77,7 +77,6 @@ export async function ensureDevcontainerCliPresent(cliDebugMode = false): Promis
 }
 
 export async function validateFeatureSchema(pathToAFeatureDir: string): Promise<boolean> {
-
     const ajv = new Ajv();
     ajv.addSchema(devContainerFeatureSchema);
     const validate = ajv.compile(devContainerFeatureSchema);
@@ -92,10 +91,9 @@ export async function validateFeatureSchema(pathToAFeatureDir: string): Promise<
 
     const featureJson = await readLocalFile(devContainerFeaturePath, 'utf8');
 
-
     const isValid = validate(JSON.parse(featureJson));
     if (!isValid) {
-        core.setFailed(`(!) ERR: '${devContainerFeaturePath}' is not valid:`);
+        core.error(`(!) ERR: '${devContainerFeaturePath}' is not valid:`);
 
         const output = JSON.stringify(validate.errors, undefined, 4);
         core.info(output);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "./src", /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "strict": true, /* Enable all strict type-checking options. */
     "noImplicitAny": true, /* Raise error on expressions and declarations with an implied 'any' type. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "resolveJsonModule": true,
   },
   "exclude": [
     "node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -736,6 +736,13 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@types/ajv@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/ajv/-/ajv-1.0.0.tgz#4fb2440742f2f6c30e7fb0797b839fc6f696682a"
+  integrity sha512-yGSqw9/QKd5FXbTNrSANcJ6IHWeNhA+gokXqmlPquJgLDC87d4g2FGPs+AlCeGG0GuZXmPq42hOFA2hnPymCLw==
+  dependencies:
+    ajv "*"
+
 "@types/babel__core@^7.1.14":
   version "7.1.19"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.19.tgz#7b497495b7d1b4812bdb9d02804d0576f43ee460"
@@ -841,6 +848,16 @@ acorn@^8.8.0:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
+
+ajv@*, ajv@^8.11.2:
+  version "8.11.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.2.tgz#aecb20b50607acf2569b6382167b65a96008bb78"
+  integrity sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
 
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
@@ -2176,6 +2193,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -2593,6 +2615,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
closes: https://github.com/devcontainers/action/issues/108
ref: https://github.com/devcontainers/spec/issues/140

Take the published `devcontainer-feature.json` schema (https://github.com/devcontainers/spec/pull/152) and uses it to validate the repo contents before publishing, emitting an error if a Feature does not follow the published schema.

Adds unit tests to validate behavior

Example of a schema failure:

https://github.com/codspace/features-with-joshspicer-custom-action/actions/runs/3742904740/jobs/6354427166
<img width="1467" alt="image" src="https://user-images.githubusercontent.com/23246594/208733145-aea54ce2-82df-4633-a7b3-92cd73abdaf3.png">
