### PR TITLE
Change interface to match v0.53.0

### DIFF
--- a/src/contracts/collection.ts
+++ b/src/contracts/collection.ts
@@ -10,7 +10,7 @@ export interface GitHubMetadata {
 }
 
 export interface PublishResult {
-    publishedVersions: string[];
+    publishedTags: string[];
     digest:            string;
     version:           string;
 }


### PR DESCRIPTION
https://github.com/devcontainers/cli/blob/9444540283b236298c28f397dea879e7ec222ca1/src/spec-node/collectionCommonUtils/publishCommandImpl.ts#L63

I've changed `publishedVersions` to `publishedTags`, so updating the interface here to match.  This field isn't used today so the order of release shouldn't matter.


release ref: https://github.com/devcontainers/cli/pull/680
change: https://github.com/devcontainers/cli/pull/670