### PR TITLE
Bump node from 16 to 20

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-16",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-20",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-20",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - name: Set Node.js 16.x
+      - name: Set Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Update Schemas
         run: yarn fetch-schemas

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
     
-      - name: Set Node.js 16.x
+      - name: Set Node.js 20.x
         uses: actions/setup-node@v2.5.1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Update Schemas
         run: yarn fetch-schemas

--- a/action.yml
+++ b/action.yml
@@ -75,5 +75,5 @@ inputs:
       Published Template IDs will be prefixed with the namespace.
       If omitted, this value will default to the source repo name
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Runs are currently showing the following warning message, bumping Node.js version to 20 to resolve this.

`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: devcontainers/action@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`