### PR TITLE
Fixes: mounts may contain string items

### DIFF
--- a/src/contracts/features.ts
+++ b/src/contracts/features.ts
@@ -15,7 +15,7 @@ export interface Feature {
     licenseURL?: string;
     options?: Record<string, IOption>;
     containerEnv?: Record<string, string>;
-    mounts?: Mount[];
+    mounts?: (Mount|string)[];
     init?: boolean;
     privileged?: boolean;
     capAdd?: string[];


### PR DESCRIPTION
https://github.com/devcontainers/cli/blob/2a6ab1ac82f4917654205e2a9b1ac928260d902e/.devcontainer/devcontainer.json#L15

I know this is `devcontainer.json`, but yes the `devcontainer-feature.json` also supports this.