### PR TITLE
Default should not be required for FeatureOptions

### DIFF
--- a/src/schemas/devContainerFeature.schema.json
+++ b/src/schemas/devContainerFeature.schema.json
@@ -243,8 +243,7 @@
             }
           },
           "required": [
-            "type",
-            "default"
+            "type"
           ],
           "type": "object"
         },


### PR DESCRIPTION
While working on publishing my own devcontainer feature using this action, I ran into validation errors because my feature included an option with no default, no enum and no proposals. Basically just a string option that looks like this:

```
    "options": {
        "version": {
            "type": "string",
            "description": "Version number"
        }
    }
```

Both [the docs](https://containers.dev/implementors/features/#options-property) and [the implementation of the cli](https://github.com/devcontainers/cli/blob/30d2105e3b277f6c33808500b1ebef881b414b20/src/spec-configuration/containerFeaturesConfiguration.ts#L86) seem to agree this is okay. And my feature seems to work fine both with the cli and in vscode.

So, I think we should update the json schema used by this GH action to not require a default.

Let me know if I am missing something. And thanks for all your great work on devcontainers!